### PR TITLE
fix dates initialisation

### DIFF
--- a/src/classes/DateFormatter.js
+++ b/src/classes/DateFormatter.js
@@ -1,7 +1,7 @@
 export default class DateFormatter {
   constructor(epoch) {
     this.date = new Date(parseInt(epoch));
-    const [month, day, year] = this.date.toLocaleDateString().split("/");
+    const [month, day, year] = [this.date.getMonth() + 1, this.date.getDate(), this.date.getFullYear()]
     this.month = month;
     this.day = day;
     this.formattedYear = year;


### PR DESCRIPTION
Hi! `toLocaleString` method depends on the user locale. Some regions do not have '/' in their localized dates
![12131](https://user-images.githubusercontent.com/4655259/58298590-bd181b80-7de4-11e9-9630-a30f71e48110.png)
